### PR TITLE
#30: Prettier ignoring normandy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-src/normandy/**/*.*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "parser": "flow",
   "singleQuote": true,
   "trailingComma": "all",
 }

--- a/src/normandy/App.js
+++ b/src/normandy/App.js
@@ -12,15 +12,13 @@ import Router, {
 } from 'normandy/routes';
 import reducers from 'normandy/state';
 
-const middleware = [
-  routerMiddleware,
-  thunk,
-];
+const middleware = [routerMiddleware, thunk];
 
-const store = createStore(reducers, reducers(undefined, { type: 'initial' }), compose(
-  applyMiddleware(...middleware),
-  routerEnhancer,
-));
+const store = createStore(
+  reducers,
+  reducers(undefined, { type: 'initial' }),
+  compose(applyMiddleware(...middleware), routerEnhancer),
+);
 
 const initialLocation = store.getState().router;
 if (initialLocation) {

--- a/src/normandy/routerUtils.js
+++ b/src/normandy/routerUtils.js
@@ -23,7 +23,6 @@ export const searchRouteTree = (tree, name, currentUrl = '') => {
   return null;
 };
 
-
 // Given a route (e.g. `/hello/:id/there`), finds params that need to be
 // populated (e.g. `:id`) and returns a string with populated values.
 export const replaceUrlVariables = (url, params) => {

--- a/src/normandy/routes.js
+++ b/src/normandy/routes.js
@@ -18,7 +18,6 @@ import RecipeDetailPage from 'normandy/components/recipes/RecipeDetailPage';
 
 import { searchRouteTree, replaceUrlVariables } from './routerUtils';
 
-
 /**
  * @type {Route}
  * @property {Component} component    React component used to render route
@@ -148,11 +147,7 @@ export const getNamedRoute = (name, params = {}) => {
   return null;
 };
 
-export const {
-  reducer,
-  middleware,
-  enhancer,
-} = routerForBrowser({
+export const { reducer, middleware, enhancer } = routerForBrowser({
   routes,
   basename: '',
 });
@@ -167,7 +162,11 @@ export default class Router extends React.PureComponent {
 
   render() {
     const { router } = this.props;
-    const content = router.route ? <router.result.component /> : <MissingPage />;
+    const content = router.route ? (
+      <router.result.component />
+    ) : (
+      <MissingPage />
+    );
     return <App>{content}</App>;
   }
 }


### PR DESCRIPTION
- Fixes #30 
  - Prettier was ignoring Normandy due to an error when it hit a decorator (`@`)
  - This patch changes the Prettier parser from `flow` to `babylon`, which supports flow types _and_ decorators.
- This patch also contains the handful of Prettier format fixes within Normandy.