### PR TITLE
Fixup following the merge of PR #75

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
       # run tests!
       - run: yarn test
 
+      # build all the things!
+      - run: yarn run build
+
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then


### PR DESCRIPTION
the "yarn run build" wasn't necessary anymore to lint the files (we do it explicitely in the "yarn run lint" step), but it's still needed to build the files in order to deploy them (later)