### PR TITLE
eslint things for real

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "eject": "react-scripts eject",
     "lint:flow": "flow",
     "lint:less": "stylelint 'src/**/*.less' --config .stylelintrc",
-    "lint:prettier-eslint": "prettier-eslint --list-different 'src/**/*.js' | ./lint_problems.sh",
-    "lint:prettier-eslintfix": "prettier-eslint --write 'src/**/*.js'",
-    "lint": "yarn run lint:flow && yarn run lint:prettier-eslint && yarn run lint:less"
+    "lint:eslint": "eslint -c node_modules/eslint-config-react-app/index.js --max-warnings 0 'src/**/*.js'",
+    "lint:eslintfix": "eslint -c node_modules/eslint-config-react-app/index.js --max-warnings 0 --fix 'src/**/*.js'",
+    "lint:prettier-eslint": "prettier-eslint --list-different 'src/**/*.js' | ./lint_problems.sh && yarn run lint:eslint",
+    "lint:prettier-eslintfix": "prettier-eslint --write 'src/**/*.js' && yarn run lint:eslintfix",
+    "lint": "yarn run lint:flow && yarn run lint:prettier-eslint && yarn run lint:eslint && yarn run lint:less"
   },
   "devDependencies": {
     "babel-plugin-import": "^1.6.5",

--- a/src/console/App.test.js
+++ b/src/console/App.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import App from './App';
 import { shallow } from 'enzyme';
 

--- a/src/console/index.js
+++ b/src/console/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import ReactDOM from 'react-dom';
 import Root from './App';
 

--- a/src/normandy/App.test.js
+++ b/src/normandy/App.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import App from './App';
 import { shallow } from 'enzyme';
 

--- a/src/normandy/tests/mockStore.js
+++ b/src/normandy/tests/mockStore.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { Route, Redirect, Switch } from 'react-router';
 import { Provider } from 'react-redux';
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';

--- a/src/normandy/tests/utils/test_handleError.js
+++ b/src/normandy/tests/utils/test_handleError.js
@@ -1,4 +1,4 @@
-import APIClient, { APIError } from 'normandy/utils/api';
+import { APIError } from 'normandy/utils/api';
 import { ValidationError } from 'normandy/utils/forms';
 import handleError, { ERR_MESSAGES } from 'normandy/utils/handleError';
 import {


### PR DESCRIPTION
Fixes #79

I didn't realize in #75 that `prettier-eslint` is only useful to fix things, not to warn about things. So now we need to run eslint twice. Sad panda.

**To review**
Pull, run `yarn lint`, check out `package.json`