### PR TITLE
Show email when logged in, fixes #198

### DIFF
--- a/src/components/auth/AuthButton.js
+++ b/src/components/auth/AuthButton.js
@@ -27,11 +27,9 @@ export default class AuthButton extends React.Component {
     const nickname = userProfile.get('nickname');
     const email = userProfile.get('email');
     return (
-      <div>
+      <div title={`Email: ${email}`}>
         <div className="no-bold">Logged in as</div>
         {nickname}
-        <br />
-        {email}
       </div>
     );
   }

--- a/src/components/auth/AuthButton.js
+++ b/src/components/auth/AuthButton.js
@@ -23,11 +23,15 @@ export default class AuthButton extends React.Component {
     userProfile: PropTypes.object,
   };
 
-  popoverTitle(nickname) {
+  popoverTitle(userProfile) {
+    const nickname = userProfile.get('nickname');
+    const email = userProfile.get('email');
     return (
       <div>
         <div className="no-bold">Logged in as</div>
         {nickname}
+        <br />
+        {email}
       </div>
     );
   }
@@ -44,12 +48,11 @@ export default class AuthButton extends React.Component {
 
   render() {
     if (this.props.userProfile) {
-      const nickname = this.props.userProfile.get('nickname');
       const picture = this.props.userProfile.get('picture');
       return (
         <Popover
           content={this.menu()}
-          title={this.popoverTitle(nickname)}
+          title={this.popoverTitle(this.props.userProfile)}
           trigger="click"
           placement="bottomRight"
         >


### PR DESCRIPTION
fixes #198

In [the issue](https://github.com/mozilla/delivery-console/issues/198) I made the case that I'm always wonder who I logged in as because my email is different for three different identities where I'm called "Peter Bengtsson". But perhaps it's just me. Either way, I think the change is cheap and it helps a little. 

<img width="366" alt="screen shot 2018-06-20 at 3 31 31 pm" src="https://user-images.githubusercontent.com/26739/41680373-4c6cec84-749f-11e8-98cc-30b73c81644c.png">

