### PR TITLE
User profile fetch called twice

### DIFF
--- a/src/components/data/QueryAuth0.js
+++ b/src/components/data/QueryAuth0.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { userProfileReceived, loginFailed, logUserIn } from 'console/state/auth/actions';
+import { loginFailed, logUserIn, userProfileReceived } from 'console/state/auth/actions';
 import { getAccessToken } from 'console/state/auth/selectors';
 import { finishAuthenticationFlow } from 'console/utils/auth0';
 
@@ -12,44 +12,24 @@ import { finishAuthenticationFlow } from 'console/utils/auth0';
     accessToken: getAccessToken(state),
   }),
   {
-    userProfileReceived,
     loginFailed,
     logUserIn,
+    userProfileReceived,
   },
 )
 @withRouter
 export default class QueryAuth0 extends React.PureComponent {
   static propTypes = {
     accessToken: PropTypes.string,
-    userProfileReceived: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     loginFailed: PropTypes.func.isRequired,
     logUserIn: PropTypes.func.isRequired,
+    userProfileReceived: PropTypes.func.isRequired,
   };
 
-  // The motivation for using componentWILLMount instead of the more regular componentDidMount
-  // is because we don't worry about server-side rendering React AND there's a chance we
-  // can synchronously read from localStorage and update state such that we have the user
-  // profile *before* the AuthButton component is mounted. Thus, the the AuthButton might
-  // not have to render the "Log in" button at all since this method will dispatch the
-  // user profile before it renders.
-  async componentWillMount() {
-    const { userProfileReceived, history, loginFailed, logUserIn } = this.props;
+  async componentDidMount() {
+    const { history, loginFailed, logUserIn, userProfileReceived } = this.props;
     let authResult;
-    let userProfileSub;
-
-    const localAuthResult = JSON.parse(localStorage.getItem('authResult'));
-
-    if (localAuthResult && localAuthResult.idTokenPayload) {
-      // The user profile was stored in localStorage! Update the store right away with this
-      // right now.
-      userProfileReceived(localAuthResult.idTokenPayload);
-      // Remember with which "sub" we updated the state of the user profile.
-      // The reason it's valuable is because you might have old localStorage state
-      // stuck in your browser, but arriving here with an window.location.hash (from the
-      // implicit grant) that ultimately points to a new/different user.
-      userProfileSub = localAuthResult.idTokenPayload.sub;
-    }
 
     try {
       authResult = await finishAuthenticationFlow();
@@ -61,7 +41,7 @@ export default class QueryAuth0 extends React.PureComponent {
       // It if was null from finishAuthenticationFlow() it means it didn't pick anything
       // up from the window.location.hash so we can potentially use what was stored in
       // localStorage.
-      authResult = localAuthResult;
+      authResult = JSON.parse(localStorage.getItem('authResult'));
     }
 
     if (authResult) {
@@ -71,10 +51,7 @@ export default class QueryAuth0 extends React.PureComponent {
       // the authresult will contain the user profile as .idTokenPayload
       // included with the accessToken. Use this now to update the state so that we
       // can display the name and avatar you logged in as.
-      if (!userProfileSub || userProfileSub !== authResult.idTokenPayload.sub) {
-        // Only dispatch if we haven't already do so with this profile.
-        userProfileReceived(authResult.idTokenPayload);
-      }
+      userProfileReceived(authResult.idTokenPayload);
 
       if (state) {
         history.push(state);

--- a/src/components/data/QueryAuth0.js
+++ b/src/components/data/QueryAuth0.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { fetchUserProfile, loginFailed, logUserIn } from 'console/state/auth/actions';
+import { userProfileReceived, loginFailed, logUserIn } from 'console/state/auth/actions';
 import { getAccessToken } from 'console/state/auth/selectors';
 import { finishAuthenticationFlow } from 'console/utils/auth0';
 
@@ -12,7 +12,7 @@ import { finishAuthenticationFlow } from 'console/utils/auth0';
     accessToken: getAccessToken(state),
   }),
   {
-    fetchUserProfile,
+    userProfileReceived,
     loginFailed,
     logUserIn,
   },
@@ -21,15 +21,35 @@ import { finishAuthenticationFlow } from 'console/utils/auth0';
 export default class QueryAuth0 extends React.PureComponent {
   static propTypes = {
     accessToken: PropTypes.string,
-    fetchUserProfile: PropTypes.func.isRequired,
+    userProfileReceived: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     loginFailed: PropTypes.func.isRequired,
     logUserIn: PropTypes.func.isRequired,
   };
 
+  // The motivation for using componentWILLMount instead of the more regular componentDidMount
+  // is because we don't worry about server-side rendering React AND there's a chance we
+  // can synchronously read from localStorage and update state such that we have the user
+  // profile *before* the AuthButton component is mounted. Thus, the the AuthButton might
+  // not have to render the "Log in" button at all since this method will dispatch the
+  // user profile before it renders.
   async componentWillMount() {
-    const { fetchUserProfile, history, loginFailed, logUserIn } = this.props;
+    const { userProfileReceived, history, loginFailed, logUserIn } = this.props;
     let authResult;
+    let userProfileSub;
+
+    const localAuthResult = JSON.parse(localStorage.getItem('authResult'));
+
+    if (localAuthResult && localAuthResult.idTokenPayload) {
+      // The user profile was stored in localStorage! Update the store right away with this
+      // right now.
+      userProfileReceived(localAuthResult.idTokenPayload);
+      // Remember with which "sub" we updated the state of the user profile.
+      // The reason it's valuable is because you might have old localStorage state
+      // stuck in your browser, but arriving here with an window.location.hash (from the
+      // implicit grant) that ultimately points to a new/different user.
+      userProfileSub = localAuthResult.idTokenPayload.sub;
+    }
 
     try {
       authResult = await finishAuthenticationFlow();
@@ -38,24 +58,27 @@ export default class QueryAuth0 extends React.PureComponent {
     }
 
     if (!authResult) {
-      authResult = JSON.parse(localStorage.getItem('authResult'));
+      // It if was null from finishAuthenticationFlow() it means it didn't pick anything
+      // up from the window.location.hash so we can potentially use what was stored in
+      // localStorage.
+      authResult = localAuthResult;
     }
 
     if (authResult) {
       const { state } = authResult;
       logUserIn(authResult);
-      fetchUserProfile(authResult.accessToken);
+      // Since we include 'id_token' for the 'responseType' in auth0.WebAuth
+      // the authresult will contain the user profile as .idTokenPayload
+      // included with the accessToken. Use this now to update the state so that we
+      // can display the name and avatar you logged in as.
+      if (!userProfileSub || userProfileSub !== authResult.idTokenPayload.sub) {
+        // Only dispatch if we haven't already do so with this profile.
+        userProfileReceived(authResult.idTokenPayload);
+      }
 
       if (state) {
         history.push(state);
       }
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { accessToken, fetchUserProfile } = this.props;
-    if (nextProps.accessToken && accessToken !== nextProps.accessToken) {
-      fetchUserProfile(nextProps.accessToken);
     }
   }
 

--- a/src/state/auth/actions.js
+++ b/src/state/auth/actions.js
@@ -8,12 +8,11 @@ import {
 } from 'console/state/action-types';
 
 export function userProfileReceived(profile) {
-  return dispatch => {
+  return dispatch =>
     dispatch({
       type: USER_PROFILE_RECEIVE,
       profile,
     });
-  };
 }
 
 export function loginFailed(error) {

--- a/src/state/auth/actions.js
+++ b/src/state/auth/actions.js
@@ -6,20 +6,13 @@ import {
   USER_LOGOUT,
   USER_PROFILE_RECEIVE,
 } from 'console/state/action-types';
-import { fetchUserInfo } from 'console/utils/auth0';
 
 export function userProfileReceived(profile) {
-  return dispatch =>
+  return dispatch => {
     dispatch({
       type: USER_PROFILE_RECEIVE,
       profile,
     });
-}
-
-export function fetchUserProfile(accessToken) {
-  return async dispatch => {
-    const profile = await fetchUserInfo(accessToken);
-    dispatch(userProfileReceived(profile));
   };
 }
 

--- a/src/utils/auth0.js
+++ b/src/utils/auth0.js
@@ -27,14 +27,3 @@ export function finishAuthenticationFlow() {
     });
   });
 }
-
-export function fetchUserInfo(accessToken) {
-  return new Promise((resolve, reject) => {
-    webAuth.client.userInfo(accessToken, (err, userInfo) => {
-      if (err) {
-        reject(new Error(err));
-      }
-      resolve(userInfo);
-    });
-  });
-}


### PR DESCRIPTION
Fixes #219


First I just wanted to remove the extra call to `fetchUserProfile` in `componentWillReceiveProps` but then I realized that we already fetch the user profile with our `webAuth.authorize({...})` call because we use `responseType: 'token id_token'`. 

Secondly, if the user profile is already stored in localStorage we can set in Redux BEFORE the `<AuthButton/>` component mounts meaning, if the user is logged in and nothing major is happening, we can go straight to displaying the `this.props.userProfile` there. No flashing of the "Log in" button. 