### PR TITLE
Can't manually remove the error messages

### DIFF
--- a/src/utils/handleError.js
+++ b/src/utils/handleError.js
@@ -1,4 +1,4 @@
-import { message as AntMessage } from 'antd';
+import { notification } from 'antd';
 
 import { APIError } from 'console/utils/api';
 import { ValidationError } from 'console/utils/forms';
@@ -24,7 +24,7 @@ const msgDisplayTime = 8; // seconds
 
 const defaultMethods = {
   checkUserOnline: () => navigator.onLine,
-  notifyUser: errMsg => AntMessage.error(errMsg, msgDisplayTime),
+  notifyUser: errMsg => notification.error({ message: errMsg, duration: msgDisplayTime }),
 };
 
 const handleAPIError = error => {


### PR DESCRIPTION
fixes #203 

<img width="1021" alt="screen shot 2018-06-25 at 4 33 54 pm" src="https://user-images.githubusercontent.com/26739/41874665-8730ac8e-7896-11e8-976e-144ac2aa56f8.png">

It's up to your Rehan but I think this is a better widget. Partially because it's at least *possible* to make it go away. And partly because the little red circle icon with a cross in it makes it look like something you can click to close. 
