### PR TITLE
Small style changes to history timeline

### DIFF
--- a/src/components/recipes/HistoryItem.js
+++ b/src/components/recipes/HistoryItem.js
@@ -68,25 +68,25 @@ export default class HistoryItem extends React.PureComponent {
 
     // Grab the status style from the static definition, alternatively fall back
     // to empty/'bland' display values.
-    const styles = HistoryItem.statusStyles[status] || {};
+    const statusInfo = HistoryItem.statusStyles[status] || {};
 
-    let { color = 'grey', iconType } = styles;
-    const { label } = styles;
+    let labelColor;
+    let { color: iconColor = 'grey', iconType } = statusInfo;
 
     // If the revision is the currently viewed revision, override the icon and color.
     if (revision.get('id') === this.props.selectedRevisionId) {
-      color = 'blue';
+      labelColor = 'blue';
+      iconColor = labelColor;
       iconType = 'circle-left';
     }
 
-    const icon = !iconType ? null : (
-      <Icon type={iconType} color={color} style={{ fontSize: '16px' }} />
-    );
+    const icon = !iconType ? null : <Icon type={iconType} style={{ fontSize: '16px' }} />;
 
     return {
       icon,
-      color,
-      label,
+      iconColor,
+      labelColor,
+      statusInfo,
     };
   }
 
@@ -102,22 +102,22 @@ export default class HistoryItem extends React.PureComponent {
     const { recipeId, revision, revisionNo } = this.props;
     const revisionUrl = this.getRevisionUrl();
 
-    const { icon, color, label } = this.getRevisionStyles();
+    const { icon, iconColor, labelColor, statusInfo } = this.getRevisionStyles();
 
     return (
-      <Timeline.Item color={color} dot={icon} key={revision.get('id')}>
+      <Timeline.Item color={iconColor} dot={icon} key={revision.get('id')}>
         <Popover
           overlayClassName="timeline-popover"
           content={<HistoryItemPopover revision={revision} />}
           placement="left"
         >
           <NavLink to={revisionUrl}>
-            <Tag color={icon && color}>{`Revision ${revisionNo}`}</Tag>
+            <Tag color={labelColor}>{`Revision ${revisionNo}`}</Tag>
           </NavLink>
 
-          {label && (
+          {statusInfo.label && (
             <NavLink to={reverse('recipes.approval_history', { recipeId })}>
-              <Tag color={color}>{label}</Tag>
+              <Tag color={statusInfo.color}>{statusInfo.label}</Tag>
             </NavLink>
           )}
         </Popover>

--- a/src/components/recipes/HistoryItem.js
+++ b/src/components/recipes/HistoryItem.js
@@ -117,7 +117,9 @@ export default class HistoryItem extends React.PureComponent {
 
           {statusInfo.label && (
             <NavLink to={reverse('recipes.approval_history', { recipeId })}>
-              <Tag color={statusInfo.color}>{statusInfo.label}</Tag>
+              <Tag className="status-label" color={statusInfo.color}>
+                {statusInfo.label}
+              </Tag>
             </NavLink>
           )}
         </Popover>

--- a/src/tests/components/recipes/HistoryItem.test.js
+++ b/src/tests/components/recipes/HistoryItem.test.js
@@ -1,4 +1,4 @@
-import { Timeline } from 'antd';
+import { Tag, Timeline } from 'antd';
 import { fromJS, Map } from 'immutable';
 import {
   REVISION_APPROVED,
@@ -52,8 +52,8 @@ describe('<HistoryItem>', () => {
       const el = wrapper.find(Timeline.Item);
       expect(el.props().color).toBe(color);
       expect(el.props().dot.props.type).toBe(iconType);
-      expect(el.props().dot.props.color).toBe(color);
       expect(wrapper.find(NavLink).length).toBe(2);
+      expect(wrapper.find('.status-label').get(0).props.color).toBe(color);
       expect(
         wrapper
           .find(NavLink)
@@ -113,7 +113,7 @@ describe('<HistoryItem>', () => {
       // `dot` is an Icon which should be highlighted with the appropriate icon.
       expect(el.props().dot).toBeTruthy();
       expect(el.props().dot.props.type).toBe('circle-left');
-      expect(el.props().dot.props.color).toBe('blue');
+      expect(wrapper.find(Tag).get(0).props.color).toBe('blue');
     });
 
     it('should NOT highlight when it is NOT the selected revision', () => {


### PR DESCRIPTION
Couple visual changes:
- Status labels retain their correct color when a revision is selected.
- The revision labels are either grey or blue based purely on whether they are selected or not.

I think that makes things a little clearer visually.

| BEFORE                                                                                                                                          | AFTER                                                                                                                                         |
|-------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| ![screenshot_2018-07-02 delivery console 1](https://user-images.githubusercontent.com/987136/42187733-12a66ac8-7e1f-11e8-8423-f79315ada0cf.png) | ![screenshot_2018-07-02 delivery console](https://user-images.githubusercontent.com/987136/42187741-1bd22aec-7e1f-11e8-9c55-d5ea2c4322a8.png) |

r?