### PR TITLE
Normalize the authentication error object returned by Auth0

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -31,7 +31,7 @@ export default class App extends React.Component {
     if (authError) {
       notification.error({
         message: 'Authentication Error',
-        description: `${authError.get('error')}: ${authError.get('errorDescription')}`,
+        description: `${authError.get('code')}: ${authError.get('description')}`,
         duration: 0,
       });
     }

--- a/src/state/auth/selectors.js
+++ b/src/state/auth/selectors.js
@@ -11,7 +11,7 @@ export function getAccessToken(state, defaultsTo = null) {
  *
  * @param state  The current state
  * @param defaultsTo  A fallback value
- * @returns {Immutable.Map({error: String, errorDescription: String})}
+ * @returns {Immutable.Map({code: String, description: String})}
  */
 export function getError(state, defaultsTo = null) {
   return state.auth.session.get('error', defaultsTo);

--- a/src/utils/auth0.js
+++ b/src/utils/auth0.js
@@ -11,6 +11,27 @@ export const webAuth = new auth0.WebAuth({
   scope: 'openid profile email',
 });
 
+/**
+ * A helper function to normalize the shape of the error object returned by Auth0.
+ * Ideas borrowed from:
+ * https://github.com/auth0/auth0.js/blob/056835b054d6f154611a509f383e1c898e9881e7/src/helper/response-handler.js#L45
+ *
+ * @param err The error object returned by Auth0
+ */
+function normalizeErrorObject(err) {
+  const errObj = {};
+  errObj.code = err.error || err.code || err.error_code || err.status || null;
+  errObj.description =
+    err.errorDescription ||
+    err.error_description ||
+    err.description ||
+    err.error ||
+    err.details ||
+    err.err ||
+    null;
+  return errObj;
+}
+
 export function authorize(returnUrl) {
   return new Promise(resolve => {
     webAuth.authorize({
@@ -24,7 +45,7 @@ export function parseHash() {
   return new Promise((resolve, reject) => {
     webAuth.parseHash((err, authResult) => {
       if (err) {
-        reject(err);
+        reject(normalizeErrorObject(err));
       }
       resolve(authResult);
     });
@@ -35,7 +56,7 @@ export function checkSession(returnUrl) {
   return new Promise((resolve, reject) => {
     webAuth.checkSession({ state: returnUrl }, (err, authResult) => {
       if (err) {
-        reject(err);
+        reject(normalizeErrorObject(err));
       }
       resolve(authResult);
     });


### PR DESCRIPTION
I noticed that sometimes the error object was of the shape `{ error, errorDescription }` and sometimes of the shape `{ error, error_description }`. This normalizes the shape of the object as per a helper function I found in Auth0's codebase:
https://github.com/auth0/auth0.js/blob/056835b054d6f154611a509f383e1c898e9881e7/src/helper/response-handler.js#L45

r?