### PR TITLE
Generic JSON arguments field for actions

### DIFF
--- a/src/components/forms/FormItem.js
+++ b/src/components/forms/FormItem.js
@@ -71,15 +71,17 @@ export default class FormItem extends React.PureComponent {
     return (
       <ul className="error-list">
         {Object.entries(errors).map(([k, v]) => {
-          if (typeof v === 'string') {
-            return <li key={k}>{`${k}: ${v}`}</li>;
-          } else if (v instanceof Array) {
-            return <li key={k}>{`${k}: ${v.join(' ')}`}</li>;
+          let formattedValue = v;
+
+          if (v instanceof Array) {
+            formattedValue = v.join(' ');
+          } else if (typeof v === 'object') {
+            formattedValue = this.renderErrorList(v);
           }
 
           return (
             <li key={k}>
-              {k} {this.renderErrorList(v)}
+              <code>{k}</code> {formattedValue}
             </li>
           );
         })}

--- a/src/components/forms/FormItem.js
+++ b/src/components/forms/FormItem.js
@@ -67,6 +67,26 @@ export default class FormItem extends React.PureComponent {
     return value.trim();
   }
 
+  renderErrorList(errors) {
+    return (
+      <ul className="error-list">
+        {Object.entries(errors).map(([k, v]) => {
+          if (typeof v === 'string') {
+            return <li key={k}>{`${k}: ${v}`}</li>;
+          } else if (v instanceof Array) {
+            return <li key={k}>{`${k}: ${v.join(' ')}`}</li>;
+          }
+
+          return (
+            <li key={k}>
+              {k} {this.renderErrorList(v)}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
   render() {
     const {
       children,
@@ -93,9 +113,15 @@ export default class FormItem extends React.PureComponent {
     const error = get(formErrors, name);
 
     if (error) {
-      const errorString = error instanceof Array ? error.join(' ') : error;
+      let help = error;
 
-      defaultItemProps.help = errorString;
+      if (error instanceof Array) {
+        help = error.join(' ');
+      } else if (typeof error === 'object') {
+        help = this.renderErrorList(error);
+      }
+
+      defaultItemProps.help = help;
       defaultItemProps.validateStatus = 'error';
     }
     const itemProps = { ...defaultItemProps, ...customItemProps };

--- a/src/components/pages/recipes/CloneRecipePage.js
+++ b/src/components/pages/recipes/CloneRecipePage.js
@@ -10,7 +10,7 @@ import { NavLink } from 'react-router-dom';
 import GenericFormContainer from 'console/components/recipes/GenericFormContainer';
 import handleError from 'console/utils/handleError';
 import LoadingOverlay from 'console/components/common/LoadingOverlay';
-import RecipeForm from 'console/components/recipes/RecipeForm';
+import RecipeForm, { cleanRecipeData } from 'console/components/recipes/RecipeForm';
 import QueryRecipe from 'console/components/data/QueryRecipe';
 import QueryRevision from 'console/components/data/QueryRevision';
 import { createRecipe } from 'console/state/recipes/actions';
@@ -73,8 +73,9 @@ export default class CloneRecipePage extends React.PureComponent {
     };
   }
 
-  async formAction(values) {
-    return this.props.createRecipe(values);
+  async formAction(data) {
+    const cleanedData = cleanRecipeData(data);
+    return this.props.createRecipe(cleanedData);
   }
 
   renderHeader() {

--- a/src/components/pages/recipes/CreateRecipePage.js
+++ b/src/components/pages/recipes/CreateRecipePage.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 
 import handleError from 'console/utils/handleError';
 import GenericFormContainer from 'console/components/recipes/GenericFormContainer';
-import RecipeForm from 'console/components/recipes/RecipeForm';
+import RecipeForm, { cleanRecipeData } from 'console/components/recipes/RecipeForm';
 import { createRecipe } from 'console/state/recipes/actions';
 import { reverse } from 'console/urls';
 
@@ -34,8 +34,9 @@ export default class CreateRecipePage extends React.PureComponent {
     this.props.push(reverse('recipes.details', { recipeId }));
   }
 
-  async formAction(formValues) {
-    return this.props.createRecipe(formValues);
+  async formAction(data) {
+    const cleanedData = cleanRecipeData(data);
+    return this.props.createRecipe(cleanedData);
   }
 
   render() {

--- a/src/components/pages/recipes/EditRecipePage.js
+++ b/src/components/pages/recipes/EditRecipePage.js
@@ -8,9 +8,8 @@ import { connect } from 'react-redux';
 import handleError from 'console/utils/handleError';
 import GenericFormContainer from 'console/components/recipes/GenericFormContainer';
 import LoadingOverlay from 'console/components/common/LoadingOverlay';
-import RecipeForm from 'console/components/recipes/RecipeForm';
+import RecipeForm, { cleanRecipeData } from 'console/components/recipes/RecipeForm';
 import QueryRecipe from 'console/components/data/QueryRecipe';
-
 import { updateRecipe } from 'console/state/recipes/actions';
 import { getRecipe } from 'console/state/recipes/selectors';
 import { getRecipeForRevision } from 'console/state/revisions/selectors';
@@ -50,9 +49,10 @@ export default class EditRecipePage extends React.PureComponent {
     handleError('Recipe cannot be updated.', error);
   }
 
-  async formAction(formValues) {
+  async formAction(data) {
     const { recipeId } = this.props;
-    return this.props.updateRecipe(recipeId, formValues);
+    const cleanedData = cleanRecipeData(data);
+    return this.props.updateRecipe(recipeId, cleanedData);
   }
 
   render() {

--- a/src/components/recipes/JSONArgumentsField.js
+++ b/src/components/recipes/JSONArgumentsField.js
@@ -1,0 +1,35 @@
+import { Input } from 'antd';
+import { Map } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import FormItem from 'console/components/forms/FormItem';
+
+export default class JSONArgumentsField extends React.Component {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    recipeArguments: PropTypes.instanceOf(Map),
+  };
+
+  static defaultProps = {
+    disabled: false,
+    recipeArguments: new Map(),
+  };
+
+  render() {
+    const { disabled, recipeArguments } = this.props;
+
+    return (
+      <div>
+        <p className="action-info">Contextual UI is not available for this action.</p>
+        <FormItem
+          name="arguments"
+          label="JSON blob"
+          initialValue={JSON.stringify(recipeArguments, null, 2)}
+        >
+          <Input.TextArea rows="10" disabled={disabled} />
+        </FormItem>
+      </div>
+    );
+  }
+}

--- a/src/components/recipes/JSONArgumentsField.js
+++ b/src/components/recipes/JSONArgumentsField.js
@@ -21,10 +21,13 @@ export default class JSONArgumentsField extends React.Component {
 
     return (
       <div>
-        <p className="action-info">Contextual UI is not available for this action.</p>
+        <p className="action-info">
+          Contextual UI is not available for this action. A generic JSON field has been provided
+          instead.
+        </p>
         <FormItem
           name="arguments"
-          label="JSON blob"
+          label="JSON Blob"
           initialValue={JSON.stringify(recipeArguments, null, 2)}
         >
           <Input.TextArea rows="10" disabled={disabled} />

--- a/src/components/recipes/RecipeDetails.js
+++ b/src/components/recipes/RecipeDetails.js
@@ -57,7 +57,7 @@ export class ArgumentsValue extends React.PureComponent {
   };
 
   static stringifyImmutable(value) {
-    return JSON.stringify(value);
+    return JSON.stringify(value, null, 2);
   }
 
   // Determine if an object is an instance of any of the given classes

--- a/src/components/recipes/RecipeDetails.js
+++ b/src/components/recipes/RecipeDetails.js
@@ -107,7 +107,7 @@ export class ArgumentsValue extends React.PureComponent {
   render() {
     const { name, value } = this.props;
 
-    let valueRender = x => x;
+    let valueRender = x => (typeof x === 'object' ? JSON.stringify(x, null, 2) : x);
 
     if (name === 'branches') {
       valueRender = this.renderBranchTable;

--- a/src/less/forms.less
+++ b/src/less/forms.less
@@ -1,0 +1,4 @@
+.error-list {
+  margin-top: 4px;
+  padding-left: 1em;
+}

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -1,6 +1,7 @@
 @import '~antd/dist/antd.less';
 
 @import './variables';
+@import './forms';
 @import './generic';
 @import './layout';
 

--- a/src/tests/components/recipes/RecipeDetails.test.js
+++ b/src/tests/components/recipes/RecipeDetails.test.js
@@ -62,11 +62,11 @@ describe('<ArgumentsValue>', () => {
       const testData = { slug: 'one', value: { test: 'fake-value' }, ratio: 1 };
       // Test against Maps
       let value = Immutable.fromJS(testData);
-      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify(testData));
+      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify(testData, null, 2));
 
       // Test against Lists
       value = Immutable.fromJS([testData]);
-      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify([testData]));
+      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify([testData], null, 2));
     });
 
     it('should use a JSON string for copy/pasting Immutable fields', () => {


### PR DESCRIPTION
This provides a textarea for editing raw JSON blobs to set action argument values for actions that do not have custom UI developed yet. This is mostly copied over from the implementation in Normandy that was created to be a generic UI for pref-rollout.

r?