### PR TITLE
Improve filter expression and other textareas

### DIFF
--- a/src/components/recipes/JSONArgumentsField.js
+++ b/src/components/recipes/JSONArgumentsField.js
@@ -30,7 +30,7 @@ export default class JSONArgumentsField extends React.Component {
           label="JSON Blob"
           initialValue={JSON.stringify(recipeArguments, null, 2)}
         >
-          <Input.TextArea rows="10" disabled={disabled} />
+          <Input.TextArea autosize={{ minRows: 4, maxRows: 16 }} disabled={disabled} />
         </FormItem>
       </div>
     );

--- a/src/components/recipes/OptOutStudyFields.js
+++ b/src/components/recipes/OptOutStudyFields.js
@@ -42,7 +42,7 @@ export default class OptOutStudyFields extends React.Component {
               name="arguments.description"
               initialValue={recipeArguments.get('description', '')}
             >
-              <Input type="textarea" rows="3" disabled={disabled} />
+              <Input.TextArea autosize={{ minRows: 3, maxRows: 10 }} disabled={disabled} />
             </FormItem>
           </Col>
 

--- a/src/components/recipes/RecipeForm.js
+++ b/src/components/recipes/RecipeForm.js
@@ -138,7 +138,7 @@ export default class RecipeForm extends React.PureComponent {
           label="Filter Expression"
           initialValue={recipe.get('extra_filter_expression')}
         >
-          <Input disabled={isLoading} type="textarea" rows="4" />
+          <Input.TextArea disabled={isLoading} autosize={{ minRows: 4, maxRows: 16 }} />
         </FormItem>
         <FormItem name="action_id" label="Action" initialValue={recipe.getIn(['action', 'id'])}>
           <ActionSelect disabled={isLoading} />

--- a/src/less/generic.less
+++ b/src/less/generic.less
@@ -38,4 +38,9 @@ a.text-colored,
   strong {
     font-weight: 600;
   }
+
+  pre,
+  code {
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
Ant changed the way it handles textareas. This brings back textareas to fields that need them and adds autosizing.

Also a style fix for `<pre>` and `<code>` tags which have oversized text right now.

Fixes #257.

r?