### PR TITLE
Redirect STDERR to /dev/null when checking for git tag

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -16,7 +16,7 @@ function generateVersionObject() {
 
   // Look for a tag
   try {
-    version = execSync('git describe --exact-match --tags')
+    version = execSync('git describe --exact-match --tags 2>/dev/null')
       .toString('utf-8')
       .trim();
   } catch (err) {


### PR DESCRIPTION
This should prevent the `fatal: no tag exactly matches` message being output when running yarn:build.

r?