### PR TITLE
Prevent Ant styles from being imported twice

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -46,8 +46,8 @@ module.exports = function(config, env) {
   config = rewireLess.withLoaderOptions({
     javascriptEnabled: true,
   })(config, env);
-  // Use Ant LESS imports
-  config = injectBabelPlugin(['import', { libraryName: 'antd', style: true }], config);
+  // Modular imports of Ant without LESS imports
+  config = injectBabelPlugin(['import', { libraryName: 'antd' }], config);
   // Decorator support (Normandy)
   config = injectBabelPlugin('transform-decorators-legacy', config);
 


### PR DESCRIPTION
We already import the styles through [`index.less`](https://github.com/mozilla/delivery-console/blob/master/src/less/index.less#L1).

This second import is why we are still seeing requests to Ant's CDN.

r?