### PR TITLE
Make tab titles more useful, by including more information in them

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -13,7 +13,7 @@ import Routes from 'console/components/Routes';
 import CircleLogo from 'console/components/svg/CircleLogo';
 import { notifyAuthenticationError } from 'console/state/auth/actions';
 import { getError } from 'console/state/auth/selectors';
-import { getCurrentRouteTree } from 'console/state/router/selectors';
+import { getCurrentDocumentTitle } from 'console/state/router/selectors';
 import { reverse } from 'console/urls';
 
 const { Header } = Layout;
@@ -21,7 +21,7 @@ const { Header } = Layout;
 @connect(
   (state, props) => ({
     authError: getError(state),
-    routeTree: getCurrentRouteTree(state),
+    documentTitle: getCurrentDocumentTitle(state, 'Delivery Console'),
   }),
   {
     notifyAuthenticationError,
@@ -31,29 +31,11 @@ export default class App extends React.Component {
   static propTypes = {
     authError: PropTypes.object,
     history: PropTypes.object.isRequired,
-    routeTree: PropTypes.object.isRequired,
+    documentTitle: PropTypes.string.isRequired,
   };
 
-  updateDocumentTitle() {
-    const { routeTree } = this.props;
-    const documentTitle = routeTree.getIn([0, 'documentTitle']);
-    let title = 'Delivery Console';
-    if (documentTitle) {
-      title = `${documentTitle} • ${title}`;
-    }
-    document.title = title;
-  }
-
-  componentDidMount() {
-    this.updateDocumentTitle();
-  }
-
   componentDidUpdate(prevProps) {
-    const { authError, routeTree } = this.props;
-
-    if (routeTree.getIn([0, 'pathname']) !== prevProps.routeTree.getIn([0, 'pathname'])) {
-      this.updateDocumentTitle();
-    }
+    const { authError } = this.props;
 
     if (authError) {
       this.props.notifyAuthenticationError(authError);
@@ -61,8 +43,12 @@ export default class App extends React.Component {
   }
 
   render() {
+    const { documentTitle, history } = this.props;
+
+    document.title = documentTitle;
+
     return (
-      <ConnectedRouter history={this.props.history}>
+      <ConnectedRouter history={history}>
         <Layout>
           <QueryAuth0 />
           <QueryActions />

--- a/src/workflows/recipes/urls.js
+++ b/src/workflows/recipes/urls.js
@@ -4,6 +4,8 @@ import CloneRecipePage from 'console/components/pages/recipes/CloneRecipePage';
 import EditRecipePage from 'console/components/pages/recipes/EditRecipePage';
 import RecipeListingPage from 'console/components/pages/recipes/RecipeListingPage';
 import RecipeDetailPage from 'console/components/pages/recipes/RecipeDetailPage';
+import { getRevisionFromUrl } from 'console/state/router/selectors';
+import { Map } from 'immutable';
 
 export default {
   '/recipe': {
@@ -26,19 +28,31 @@ export default {
         name: 'recipes.details',
         component: RecipeDetailPage,
         crumbText: 'Details',
-        documentTitle: 'Recipe Details',
+        documentTitle: state => {
+          const recipe = getRevisionFromUrl(state, new Map()).get('recipe');
+          return ['Recipe Details', recipe && `#${recipe.get('id')} ${recipe.get('name')}`];
+        },
         routes: {
           '/edit': {
             name: 'recipes.edit',
             component: EditRecipePage,
             crumbText: 'Edit',
-            documentTitle: 'Edit Recipe',
+            documentTitle: state => {
+              const recipe = getRevisionFromUrl(state, new Map()).get('recipe');
+              return ['Edit Recipe', recipe && `#${recipe.get('id')} ${recipe.get('name')}`];
+            },
           },
           '/approval_history': {
             name: 'recipes.approval_history',
             component: ApprovalHistoryPage,
             crumbText: 'Approval History',
-            documentTitle: 'Recipe Approval History',
+            documentTitle: state => {
+              const recipe = getRevisionFromUrl(state, new Map()).get('recipe');
+              return [
+                'Recipe Approval History',
+                recipe && `#${recipe.get('id')} ${recipe.get('name')}`,
+              ];
+            },
           },
           '/clone': {
             name: 'recipes.clone',
@@ -50,7 +64,14 @@ export default {
             name: 'recipes.revision',
             component: RecipeDetailPage,
             crumbText: 'Revision Details',
-            documentTitle: 'Recipe Revision Details',
+            documentTitle: state => {
+              const revision = getRevisionFromUrl(state);
+              return [
+                'Recipe Revision',
+                revision && `#${revision.getIn(['recipe', 'id'])} rev ${revision.get('id')}`,
+                revision && `${revision.getIn(['recipe', 'name'])}`,
+              ];
+            },
             routes: {
               '/clone': {
                 name: 'recipes.revision.clone',


### PR DESCRIPTION
This is more what I had in mind when I filed #269. It makes page titles like "Recipe Details  • #127 test normandy • Delivery Console".