### PR TITLE
VPN status button not clickable

### DIFF
--- a/src/components/common/VPNStatus.js
+++ b/src/components/common/VPNStatus.js
@@ -38,7 +38,7 @@ export default class VPNStatus extends React.PureComponent {
     return (
       <span className="vpn-status">
         <QueryNormandyAdmin />
-        <Tag color={color}>
+        <Tag color={color} className="not-clickable">
           {icon} {message}
         </Tag>
       </span>

--- a/src/components/common/VPNStatus.js
+++ b/src/components/common/VPNStatus.js
@@ -38,7 +38,7 @@ export default class VPNStatus extends React.PureComponent {
     return (
       <span className="vpn-status">
         <QueryNormandyAdmin />
-        <Tag color={color} className="not-clickable">
+        <Tag color={color} className="unset-cursor">
           {icon} {message}
         </Tag>
       </span>

--- a/src/less/generic.less
+++ b/src/less/generic.less
@@ -44,3 +44,7 @@ a.text-colored,
     font-size: 12px;
   }
 }
+
+.ant-tag.not-clickable {
+  cursor: unset;
+}

--- a/src/less/generic.less
+++ b/src/less/generic.less
@@ -43,7 +43,6 @@ a.text-colored,
   code {
     font-size: 12px;
   }
-
 }
 
 /* Useful when using elements that get a 'cursor:pointer' by antd */

--- a/src/less/generic.less
+++ b/src/less/generic.less
@@ -43,8 +43,8 @@ a.text-colored,
   code {
     font-size: 12px;
   }
-}
 
-.ant-tag.not-clickable {
-  cursor: unset;
+  .ant-tag.unset-cursor {
+    cursor: unset;
+  }
 }

--- a/src/less/generic.less
+++ b/src/less/generic.less
@@ -44,7 +44,9 @@ a.text-colored,
     font-size: 12px;
   }
 
-  .ant-tag.unset-cursor {
-    cursor: unset;
-  }
+}
+
+/* Useful when using elements that get a 'cursor:pointer' by antd */
+.unset-cursor {
+  cursor: unset;
 }


### PR DESCRIPTION
Fixes #380

I wouldn't be surprised that there are better patterns for doing these kinds of CSS overrides but it solves the problem of no longer thinking that clicking the VPN status button is broken :)