### PR TITLE
date fns v2 and esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "auth0-js": "9.7.3",
     "autobind-decorator": "2.1.0",
     "connected-react-router": "4.4.1",
-    "date-fns": "1.29.0",
+    "date-fns": "2.0.0-alpha.16",
     "immutable": "3.8.2",
     "lodash": "4.17.10",
     "raven-js": "3.26.4",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"
+      "node_modules/(?!(date-fns)/)"
     ],
     "moduleNameMapper": {
       ".*\\.less$": "<rootDir>/etc/StubModule.js",

--- a/src/components/pages/recipes/RecipeListingPage.js
+++ b/src/components/pages/recipes/RecipeListingPage.js
@@ -1,7 +1,9 @@
 import { Pagination, Table } from 'antd';
 import autobind from 'autobind-decorator';
 import { push } from 'connected-react-router';
-import dateFns from 'date-fns';
+import { toDate } from 'date-fns/esm';
+import { format } from 'date-fns/esm';
+import { formatDistance } from 'date-fns/esm';
 import { List } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -129,13 +131,13 @@ export default class RecipeListingPage extends React.PureComponent {
           key="last_updated"
           dataIndex="last_updated"
           render={(text, record) => {
-            const lastUpdated = dateFns.parse(record.last_updated);
+            const lastUpdated = toDate(record.last_updated);
             return (
               <Link
                 to={reverse('recipes.details', { recipeId: record.id })}
-                title={dateFns.format(lastUpdated, 'dddd, MMMM M, YYYY h:mm A')}
+                title={format(lastUpdated, 'dddd, MMMM M, YYYY h:mm A')}
               >
-                {dateFns.distanceInWordsToNow(lastUpdated)}
+                {formatDistance(lastUpdated, new Date())}
               </Link>
             );
           }}

--- a/src/components/recipes/ApprovalDetails.js
+++ b/src/components/recipes/ApprovalDetails.js
@@ -1,4 +1,6 @@
-import dateFns from 'date-fns';
+import { format } from 'date-fns/esm';
+import { formatDistance } from 'date-fns/esm';
+import { toDate } from 'date-fns/esm';
 import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,7 +12,7 @@ export default class ApprovalDetails extends React.PureComponent {
 
   render() {
     const { request } = this.props;
-    const dateCreated = dateFns.parse(request.get('created'));
+    const dateCreated = toDate(request.get('created'));
 
     return (
       <dl className="details narrow">
@@ -18,8 +20,8 @@ export default class ApprovalDetails extends React.PureComponent {
         <dd>{request.getIn(['approver', 'email'])}</dd>
 
         <dt>Responsed</dt>
-        <dd title={dateFns.format(dateCreated, 'MMMM Do YYYY, h:mm a')}>
-          {dateFns.distanceInWordsToNow(dateCreated)}
+        <dd title={format(dateCreated, 'MMMM Do YYYY, h:mm a')}>
+          {formatDistance(dateCreated, new Date())}
         </dd>
 
         <dt>Comment</dt>

--- a/src/components/recipes/ApprovalRequest.js
+++ b/src/components/recipes/ApprovalRequest.js
@@ -1,6 +1,8 @@
 import { Card, Col, message, Row, Tag } from 'antd';
 import autobind from 'autobind-decorator';
-import dateFns from 'date-fns';
+import { format } from 'date-fns/esm';
+import { formatDistance } from 'date-fns/esm';
+import { toDate } from 'date-fns/esm';
 import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -106,7 +108,7 @@ export default class ApprovalRequest extends React.PureComponent {
       <ApprovalDetails request={approvalRequest} />
     );
 
-    const dateCreated = dateFns.parse(approvalRequest.get('created'));
+    const dateCreated = toDate(approvalRequest.get('created'));
 
     return (
       <div className="approval-history-details">
@@ -122,8 +124,8 @@ export default class ApprovalRequest extends React.PureComponent {
                   <dd>{approvalRequest.getIn(['creator', 'email'])}</dd>
 
                   <dt>Requested</dt>
-                  <dd title={dateFns.format(dateCreated, 'MMMM Do YYYY, h:mm a')}>
-                    {dateFns.distanceInWordsToNow(dateCreated)}
+                  <dd title={format(dateCreated, 'MMMM Do YYYY, h:mm a')}>
+                    {formatDistance(dateCreated, new Date())}
                   </dd>
                 </dl>
               </div>

--- a/src/components/recipes/HistoryItem.js
+++ b/src/components/recipes/HistoryItem.js
@@ -1,6 +1,8 @@
 import { Alert, Icon, Popover, Tag, Timeline } from 'antd';
 import autobind from 'autobind-decorator';
-import dateFns from 'date-fns';
+import { toDate } from 'date-fns/esm';
+import { format } from 'date-fns/esm';
+import { formatDistance } from 'date-fns/esm';
 import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -153,11 +155,11 @@ export class RevisionInfo extends React.PureComponent {
 
   render() {
     const { revision } = this.props;
-    const revisionCreationTime = dateFns.parse(revision.get('date_created'));
+    const revisionCreationTime = toDate(revision.get('date_created'));
 
-    const fullTime = dateFns.format(revisionCreationTime, 'MMMM Do YYYY, h:mm a');
-    const simpleTime = dateFns.format(revisionCreationTime, 'MM/DD/YYYY');
-    const timeAgo = dateFns.distanceInWordsToNow(revisionCreationTime);
+    const fullTime = format(revisionCreationTime, 'MMMM Do YYYY, h:mm a');
+    const simpleTime = format(revisionCreationTime, 'MM/DD/YYYY');
+    const timeAgo = formatDistance(revisionCreationTime, new Date());
 
     // Creator info is on every tooltip, contains basic metadata.
     return (
@@ -184,11 +186,11 @@ export class RequestInfo extends React.PureComponent {
     }
 
     const requestCreator = revision.getIn(['approval_request', 'creator', 'email']);
-    const requestCreationTime = dateFns.parse(revision.getIn(['approval_request', 'created']));
+    const requestCreationTime = toDate(revision.getIn(['approval_request', 'created']));
 
-    const fullTime = dateFns.format(requestCreationTime, 'MMMM Do YYYY, h:mm a');
-    const simpleTime = dateFns.format(requestCreationTime, 'MM/DD/YYYY');
-    const timeAgo = dateFns.distanceInWordsToNow(requestCreationTime);
+    const fullTime = format(requestCreationTime, 'MMMM Do YYYY, h:mm a');
+    const simpleTime = format(requestCreationTime, 'MM/DD/YYYY');
+    const timeAgo = formatDistance(requestCreationTime, new Date());
 
     return (
       <span>

--- a/src/state/revisions/selectors.js
+++ b/src/state/revisions/selectors.js
@@ -1,4 +1,5 @@
-import dateFns from 'date-fns';
+import { toDate } from 'date-fns/esm';
+import { differenceInMilliseconds } from 'date-fns/esm';
 import { Map } from 'immutable';
 
 import { getAction } from 'console/state/actions/selectors';
@@ -120,9 +121,9 @@ export function getRevisionDraftStatus(state, id) {
   const revision = getRevision(state, id);
 
   if (approvedRevision) {
-    const revisionDate = dateFns.parse(revision.get('date_created'));
-    const approvedRevisionDate = dateFns.parse(approvedRevision.get('date_created'));
-    const delta = dateFns.differenceInMilliseconds(approvedRevisionDate, revisionDate);
+    const revisionDate = toDate(revision.get('date_created'));
+    const approvedRevisionDate = toDate(approvedRevision.get('date_created'));
+    const delta = differenceInMilliseconds(approvedRevisionDate, revisionDate);
 
     if (delta < 0) {
       return REVISION_DRAFT;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,9 +2504,9 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
-date-fns@1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+date-fns@2.0.0-alpha.16:
+  version "2.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.16.tgz#d249a6c9b799252652fb9e3f25460eaf9de86ac7"
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Fixes #386 

Version 2 has had 16 alpha releases but no final release. That's unfortunate but there are 16 alpha releases so it's extremely unlikely that its API will change when a final release is made. 

One best thing about date-fns v2 is that you can use the `esm` modules to ONLY import exactly what you use. *At the moment*, it actually doesn't matter a whole lot to use. The `date-fns` part of `build/static/js/main.9b2da400.js` is now 27KB instead of 30KB before. But this way is more correct since we import explicitly. 
