### PR TITLE
fix current-revision marker icon

### DIFF
--- a/src/less/components/history-timeline.less
+++ b/src/less/components/history-timeline.less
@@ -33,7 +33,8 @@
 }
 
 .ant-timeline-item-head-custom {
-  top: 1px;
+  padding: 0;
+  top: 5px;
 }
 
 .revision-info {

--- a/src/tests/workflows/recipes/components/HistoryItem.test.js
+++ b/src/tests/workflows/recipes/components/HistoryItem.test.js
@@ -112,7 +112,7 @@ describe('<HistoryItem>', () => {
 
       // `dot` is an Icon which should be highlighted with the appropriate icon.
       expect(el.props().dot).toBeTruthy();
-      expect(el.props().dot.props.type).toBe('circle-left');
+      expect(el.props().dot.props.type).toBe('left-circle');
       expect(wrapper.find(Tag).get(0).props.color).toBe('blue');
     });
 

--- a/src/workflows/recipes/components/HistoryItem.js
+++ b/src/workflows/recipes/components/HistoryItem.js
@@ -80,6 +80,11 @@ class HistoryItem extends React.PureComponent {
       iconType = 'left-circle';
     }
 
+    // Note! There's a strange behavior when running test.
+    // When you run `yarn run test` you'll get this warning:
+    // "Warning: This icon already has a theme 'outlined'. The prop 'theme' filled will be ignored."
+    // It's because of the `theme="filled"` but we want/need that to be filled.
+    // Filed this: https://github.com/ant-design/ant-design/issues/12441
     const icon = !iconType ? null : (
       <Icon type={iconType} theme="filled" style={{ fontSize: '18px' }} />
     );

--- a/src/workflows/recipes/components/HistoryItem.js
+++ b/src/workflows/recipes/components/HistoryItem.js
@@ -77,10 +77,12 @@ class HistoryItem extends React.PureComponent {
     if (revision.get('id') === this.props.selectedRevisionId) {
       labelColor = 'blue';
       iconColor = labelColor;
-      iconType = 'circle-left';
+      iconType = 'left-circle';
     }
 
-    const icon = !iconType ? null : <Icon type={iconType} style={{ fontSize: '16px' }} />;
+    const icon = !iconType ? null : (
+      <Icon type={iconType} theme="filled" style={{ fontSize: '18px' }} />
+    );
 
     return {
       icon,


### PR DESCRIPTION
Fixes #479 

I took the liberty of not only "restoring" it but also messing with the styling a little bit. Now it looks like this:

<img width="324" alt="screen shot 2018-09-27 at 4 10 41 pm" src="https://user-images.githubusercontent.com/26739/46171968-2e142d00-c270-11e8-99da-4a9429c74c48.png">

That's slightly [different from before](https://github.com/mozilla/delivery-console/issues/479#issuecomment-425195897).