### PR TITLE
extraction of errors causes TypeError

### DIFF
--- a/src/components/forms/FormItem.js
+++ b/src/components/forms/FormItem.js
@@ -111,7 +111,7 @@ class FormItem extends React.PureComponent {
     }
 
     const defaultItemProps = {};
-    const error = name
+    const error = (name || '')
       .split('.')
       .reduce((obj, index) => (obj ? obj[index] : undefined), formErrors);
 

--- a/src/tests/components/forms/FormItem.test.js
+++ b/src/tests/components/forms/FormItem.test.js
@@ -1,4 +1,5 @@
 import WrappedFormItem from 'console/components/forms/FormItem';
+import { render } from 'react-testing-library';
 
 const FormItem = WrappedFormItem.wrappedComponent;
 
@@ -19,9 +20,9 @@ describe('<FormItem>', () => {
   };
 
   it('should work', () => {
-    const wrapper = () => shallow(<WrappedFormItem {...props} />);
-
-    expect(wrapper).not.toThrow();
+    const { container } = render(<FormItem {...props} />);
+    const input = container.querySelector('input[type="text"]');
+    expect(input).not.toBeNull();
   });
 
   it('should correctly trim whitespace', () => {


### PR DESCRIPTION
Fixes #543

I know this change is good because I was able to reproduce it locally and fix. I'm a bit stumped as to why the unit test didn't cover that. 