### PR TITLE
Copy-to-clipboard for null things

### DIFF
--- a/src/tests/workflows/recipes/components/RecipeDetails.test.js
+++ b/src/tests/workflows/recipes/components/RecipeDetails.test.js
@@ -37,6 +37,26 @@ describe('<ArgumentsValue>', () => {
     );
   });
 
+  it('should render default value if extra_filter_expression is null', () => {
+    const wrapper = shallow(
+      <ArgumentsValue value={null} name="extra_filter_expression" defaultValue={<i>Nada!</i>} />,
+    );
+    expect(wrapper.find('.value').html()).toBe('<div class="value"><i>Nada!</i></div>');
+  });
+
+  it('should not render default value if extra_filter_expression is "false"', () => {
+    const wrapper = shallow(
+      <ArgumentsValue
+        value={'false'}
+        name="extra_filter_expression"
+        defaultValue={<i>Nada!</i>}
+      />,
+    );
+    expect(wrapper.find('.value').html()).toBe(
+      '<div class="value"><pre><code>false</code></pre></div>',
+    );
+  });
+
   it('should render branches as a table', () => {
     const value = Immutable.fromJS([
       { slug: 'one', value: 1, ratio: 1 },
@@ -73,6 +93,16 @@ describe('<ArgumentsValue>', () => {
     expect(content).toContain('<code>Peter</code>');
     expect(content).toContain('<code>2</code>');
     expect(content).toContain('<code>false</code>');
+  });
+
+  it('should display copy-to-clipboard tag for truthy values', () => {
+    let wrapper = shallow(<ArgumentsValue value={'something'} />);
+    expect(wrapper.find('.copy-icon').exists()).toBeTruthy();
+  });
+
+  it('should not display copy-to-clipboard tag for falsy values', () => {
+    let wrapper = shallow(<ArgumentsValue value={null} />);
+    expect(wrapper.find('.copy-icon').exists()).toBeFalsy();
   });
 
   describe('immutable objects', () => {

--- a/src/workflows/recipes/components/RecipeDetails.js
+++ b/src/workflows/recipes/components/RecipeDetails.js
@@ -36,7 +36,8 @@ export default class RecipeDetails extends React.PureComponent {
             </dt>
             <ArgumentsValue
               name="extra_filter_expression"
-              value={extraFilterExpression ? extraFilterExpression : <em>none</em>}
+              value={extraFilterExpression}
+              defaultValue={<em>none</em>}
             />
           </dl>
         </Card>
@@ -68,6 +69,7 @@ export default class RecipeDetails extends React.PureComponent {
 export class ArgumentsValue extends React.PureComponent {
   static propTypes = {
     name: PropTypes.string,
+    defaultValue: PropTypes.any,
     value: PropTypes.any,
     actionName: PropTypes.string,
   };
@@ -75,6 +77,7 @@ export class ArgumentsValue extends React.PureComponent {
   static defaultProps = {
     name: null,
     actionName: null,
+    defaultValue: null,
   };
 
   static stringifyImmutable(value) {
@@ -264,7 +267,7 @@ export class ArgumentsValue extends React.PureComponent {
   }
 
   render() {
-    const { name, actionName, value } = this.props;
+    const { actionName, defaultValue, name, value } = this.props;
 
     let valueRender = x => (typeof x === 'object' ? JSON.stringify(x, null, 2) : x);
     let argumentsValueClassName = 'arguments-value';
@@ -282,15 +285,22 @@ export class ArgumentsValue extends React.PureComponent {
       valueRender = this.renderPreferencesTable;
     }
 
-    let textToCopy = value === undefined ? '' : value.toString();
-    if (this.compareInstances(value, [List, Map])) {
-      textToCopy = ArgumentsValue.stringifyImmutable(value);
+    // It's not good enough to check if the value is falsy to determine whether to show
+    // the default value instead. For example if it's "false" (type boolean) we want to
+    // display that as code. E.g. `<code>false</code>` or `<code>0</code>`.
+    let realValue = !(value === null || value === undefined);
+    let textToCopy = null;
+    if (realValue) {
+      textToCopy = value === undefined ? '' : value.toString();
+      if (this.compareInstances(value, [List, Map])) {
+        textToCopy = ArgumentsValue.stringifyImmutable(value);
+      }
     }
 
     return (
       <dd className={argumentsValueClassName}>
-        <div className="value">{valueRender(value)}</div>
-        {value ? (
+        <div className="value">{realValue ? valueRender(value) : defaultValue}</div>
+        {realValue ? (
           <Tooltip mouseEnterDelay={1} title="Copy to Clipboard" placement="top">
             <CopyToClipboard className="copy-icon" text={textToCopy}>
               <Icon type="copy" />


### PR DESCRIPTION
Fixes #649

It took a couple of minutes to make the real change and almost an hour to get the tests to work. 

Apparently `expect(wrapper.find('.copy-icon').exists()).toBeTruthy();` works but `expect(wrapper.find('i.copy-icon').exists()).toBeTruthy();` doesn't even though, when console logged, I can definitely see it's `<i class="copy-icon">`. :(

I think this test file, by the way, is a great candidate to rewrite with `react-testing-library`.