### PR TITLE
Changing column sort of recipes isn't working

### DIFF
--- a/src/components/tables/DataList.js
+++ b/src/components/tables/DataList.js
@@ -29,10 +29,12 @@ class DataList extends React.PureComponent {
     ordering: PropTypes.string,
     getUrlFromRecord: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,
+    defaultOrdering: PropTypes.string,
   };
 
   static defaultProps = {
     ordering: null,
+    defaultOrdering: null,
   };
 
   static getSortOrder = (field, ordering) => {
@@ -75,6 +77,8 @@ class DataList extends React.PureComponent {
     if (Object.keys(sorter).length) {
       const prefix = sorter.order === 'ascend' ? '' : '-';
       ordering = `${prefix}${sorter.field}`;
+    } else if (this.props.defaultOrdering) {
+      ordering = this.props.defaultOrdering;
     }
 
     this.props.push(

--- a/src/workflows/recipes/pages/RecipeListingPage.js
+++ b/src/workflows/recipes/pages/RecipeListingPage.js
@@ -212,6 +212,7 @@ class RecipeListingPage extends React.PureComponent {
             columnRenderers={columnRenderers}
             dataSource={recipes.toJS()}
             ordering={ordering}
+            defaultOrdering={ordering === '-last_updated' ? 'last_updated' : '-last_updated'}
             getUrlFromRecord={this.getUrlFromRecord}
             status={status}
             action={action}


### PR DESCRIPTION
Fixes #650 

I'm not in love with this solution. In particular, if you load the recipe listing page it sorts by `-last_updated` automatically in the XHR request. Suppose you want to change to sort by Name, clicking it once changes the pushState url to `?ordering=name`, click again and it becomes `?ordering=-name` and when you click it a *third* time the ordering, in the pushState should return to nothing. But it doesn't. It changes it to `?ordering=-last_updated` and you basically can't get the pushState to being nothing. Basically, once you've clicked on any column head you *always* have `?ordering=...something...`. Perhaps not the end of the world. At least it works as expected now. 