### PR TITLE
TypeError when searching recipes

### DIFF
--- a/src/state/network/actions.js
+++ b/src/state/network/actions.js
@@ -46,6 +46,7 @@ export function makeApiRequest(requestId, root, endpoint, options = {}) {
         type: REQUEST_FAILURE,
         requestId,
         error,
+        endpoint,
       });
 
       throw error;

--- a/src/state/network/reducers.js
+++ b/src/state/network/reducers.js
@@ -41,6 +41,7 @@ function requests(state = defaultState.get('requests'), action) {
         new Map({
           inProgress: false,
           error: fromJS(action.error),
+          endpoint: action.endpoint,
         }),
       );
 


### PR DESCRIPTION
Fixes #604

THIS IS WORK-IN-PROGRESS! I know the tests don't pass but it should be easy to fix. The biggest flaws are:

1) It shows the same error repeatedly for every `componentDidUpdate` so we'd need to "memoize" that. 
2) I'm not sure this is pretty enough. 
3) Should we include the endpoint used when testing the normandyAdmin thing?

The (visual) result is something like this:
<img width="1411" alt="screen shot 2018-12-28 at 4 25 45 pm" src="https://user-images.githubusercontent.com/26739/50528716-f5c5fa00-0abd-11e9-911a-3908f15a3d25.png">

I'm looking for help @rehandalal. It's late Friday afternoon and I'm running out of creative juices. 

Whatever we do I think some sort of visual error message would definitely help. 