### PR TITLE
show right revision notice after publish

### DIFF
--- a/src/workflows/recipes/components/RevisionNotice.js
+++ b/src/workflows/recipes/components/RevisionNotice.js
@@ -37,10 +37,10 @@ class RevisionNotice extends React.Component {
     let type;
 
     if (status === REVISION_PENDING_APPROVAL) {
-      message = 'This is pending approval.';
+      message = 'You are viewing a draft that is pending approval.';
       type = 'warning';
     } else if (status === REVISION_REJECTED) {
-      message = 'You are viewing a rejected draft.';
+      message = 'You are viewing a draft that was rejected.';
       type = 'warning';
     } else if (draftStatus === REVISION_DRAFT) {
       message = 'You are viewing a draft.';
@@ -52,7 +52,7 @@ class RevisionNotice extends React.Component {
       message = 'This is the published version.';
       type = 'success';
     } else if (status === REVISION_APPROVED) {
-      message = 'You are viewing the approved but not published version.';
+      message = 'You are viewing a draft that has been approved but has not been published.';
       type = 'warning';
     } else {
       return null;

--- a/src/workflows/recipes/components/RevisionNotice.js
+++ b/src/workflows/recipes/components/RevisionNotice.js
@@ -52,8 +52,8 @@ class RevisionNotice extends React.Component {
       message = 'This is the published version.';
       type = 'success';
     } else if (status === REVISION_APPROVED) {
-      message = 'You are viewing the approved version.';
-      type = 'info';
+      message = 'You are viewing the approved but not published version.';
+      type = 'warning';
     } else {
       return null;
     }

--- a/src/workflows/recipes/components/RevisionNotice.js
+++ b/src/workflows/recipes/components/RevisionNotice.js
@@ -3,46 +3,57 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { REVISION_DRAFT, REVISION_OUTDATED } from 'console/state/constants';
 import {
-  isRevisionPendingApproval,
-  getRevisionDraftStatus,
-} from 'console/state/revisions/selectors';
+  REVISION_APPROVED,
+  REVISION_DRAFT,
+  REVISION_LIVE,
+  REVISION_PENDING_APPROVAL,
+  REVISION_OUTDATED,
+  REVISION_REJECTED,
+} from 'console/state/constants';
+import { getRevisionDraftStatus, getRevisionStatus } from 'console/state/revisions/selectors';
 
 @connect((state, { revision }) => ({
-  enabled: revision.getIn(['recipe', 'enabled'], false),
-  isPendingApproval: isRevisionPendingApproval(state, revision.get('id')),
-  status: getRevisionDraftStatus(state, revision.get('id')),
+  draftStatus: getRevisionDraftStatus(state, revision.get('id')),
+  status: getRevisionStatus(state, revision.get('id')),
 }))
-class RevisionNotice extends React.PureComponent {
+class RevisionNotice extends React.Component {
   static propTypes = {
-    enabled: PropTypes.bool.isRequired,
-    isPendingApproval: PropTypes.bool.isRequired,
+    draftStatus: PropTypes.string,
     status: PropTypes.string,
   };
 
-  static defaultProps = {
-    status: null,
-  };
+  // THIS SHOULDN'T BE NECESSARY
+  // https://github.com/mozilla/delivery-console/issues/680
+  shouldComponentUpdate(nextProps) {
+    const { draftStatus, status } = this.props;
+    return nextProps.draftStatus !== draftStatus || nextProps.status !== status;
+  }
 
   render() {
-    const { enabled, isPendingApproval, status } = this.props;
+    const { draftStatus, status } = this.props;
 
     let message;
     let type;
 
-    if (isPendingApproval) {
+    if (status === REVISION_PENDING_APPROVAL) {
       message = 'This is pending approval.';
       type = 'warning';
-    } else if (status === REVISION_DRAFT) {
+    } else if (status === REVISION_REJECTED) {
+      message = 'You are viewing a rejected draft.';
+      type = 'warning';
+    } else if (draftStatus === REVISION_DRAFT) {
       message = 'You are viewing a draft.';
       type = 'info';
-    } else if (status === REVISION_OUTDATED) {
+    } else if (draftStatus === REVISION_OUTDATED) {
       message = 'You are viewing an outdated version.';
       type = 'info';
-    } else if (enabled) {
+    } else if (status === REVISION_LIVE) {
       message = 'This is the published version.';
       type = 'success';
+    } else if (status === REVISION_APPROVED) {
+      message = 'You are viewing the approved version.';
+      type = 'info';
     } else {
       return null;
     }


### PR DESCRIPTION
Fixes #609 

Please review this carefully. I'm uneasy about the language about revisions and stuff. There are so many possibilities to explain the "status" of a recipe. And there are no unit tests for this stuff. 

I (*think*) these are the following new visual changes:

### When enabled
<img width="910" alt="screen shot 2019-01-02 at 11 13 03 am" src="https://user-images.githubusercontent.com/26739/50602574-a6991400-0e85-11e9-82da-06d7289f2016.png">


### When not enabled but at least approved
<img width="926" alt="screen shot 2019-01-02 at 11 13 15 am" src="https://user-images.githubusercontent.com/26739/50602596-aef14f00-0e85-11e9-94ec-dc023c106bfb.png">

### Viewing a rejected recipe without having done any new draft changes yet
<img width="790" alt="screen shot 2019-01-02 at 11 55 45 am" src="https://user-images.githubusercontent.com/26739/50602624-bc0e3e00-0e85-11e9-86e1-ef424b12e976.png">



Chances are, by the time your constructive criticism comes back about nits/failures in my business logic comes back I'll have forgotten most of what I've learned today so feel free to just push to my branch etc.

