### PR TITLE
TypeError after approving

### DIFF
--- a/src/workflows/recipes/components/ApprovalRequest.js
+++ b/src/workflows/recipes/components/ApprovalRequest.js
@@ -84,23 +84,18 @@ class ApprovalRequest extends React.PureComponent {
 
       if (error.data) {
         this.setState({ formErrors: error.data });
+      } else {
+        // If you have just approved this recipe, the next natural action is (likely) to
+        // be to publish it. It's not something you can do from the Approval request page.
+        // So, redirect back to the details page which *has* a Publish button and a notification
+        // message about that being the next action.
+        if (context.approved) {
+          const recipeId = recipe.get('id');
+          push(reverse('recipes.details', { recipeId }));
+        }
       }
     } finally {
-      this.setState(
-        {
-          isSubmitting: false,
-        },
-        () => {
-          // If you have just approved this recipe, the next natural action is (likely) to
-          // be to publish it. It's not something you can do from the Approval request page.
-          // So, redirect back to the details page which *has* a Publish button and a notification
-          // message about that being the next action.
-          if (context.approved) {
-            const recipeId = recipe.get('id');
-            push(reverse('recipes.details', { recipeId }));
-          }
-        },
-      );
+      this.setState({ isSubmitting: false });
     }
   }
 


### PR DESCRIPTION
Fixes #709

The problem was that I had done it wrong in https://github.com/mozilla/delivery-console/commit/58d77c6858b5f16fb7e37259144a91fe8fb3a0f9 altogether. The "Did you just approve? If so, let's redirect" stuff should only happen after the XHR is successful and there weren't any errors. 

For some reason, I can't see right now, the `context` becomes `undefined` inside the `finally {...}` block. If you know why I'm all ears but for now I'm just going to fix it. 