### PR TITLE
pageNumber put in the wrong place in api options

### DIFF
--- a/src/state/recipes/actions.js
+++ b/src/state/recipes/actions.js
@@ -41,7 +41,7 @@ export function fetchFilteredRecipesPage(pageNumber = 1, filters = {}) {
       data: { ...filters },
     };
     if (pageNumber !== Infinity) {
-      options.page = pageNumber;
+      options.data.page = pageNumber;
     }
     const recipes = await dispatch(makeNormandyApiRequest(requestId, 'v3/recipe/', options));
     while (pageNumber === Infinity && recipes.next) {


### PR DESCRIPTION
Fixes #776 

[Here was the mistake](https://github.com/mozilla/delivery-console/pull/761/files\#diff-53bc18e094267fc7692cb4453416a0d4L39)