### PR TITLE
js-yaml resolution upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "whatwg-fetch": "3.0.0"
   },
   "resolutions": {
-    "handlebars": "^4.0.13"
+    "handlebars": "^4.0.13",
+    "js-yaml": "^3.13.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6329,10 +6329,10 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.0, js-yaml@^3.9.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.9.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Make `yarn audit` happy. 

This is only a "security" concern for local dev and is not related to a production security concern. 

The insecure version of `js-yaml` inside `yarn.lock` exists there only because of `stylelint` which is part of `devDependencies`. This is why GitHub's builtin security alerting isn't triggering on this. Me thinks. 

