### PR TITLE
Stop using `.toArray` for Immutable Maps

### DIFF
--- a/src/workflows/recipes/components/FilterObjectForm.js
+++ b/src/workflows/recipes/components/FilterObjectForm.js
@@ -155,7 +155,7 @@ class FilterObjectForm extends React.PureComponent {
       .map(channel => {
         return { label: channel.get('value'), value: channel.get('key') };
       })
-      .toArray()
+      .reduce((reduction, value) => [...reduction, value], [])
       .sort((a, b) => {
         // The reason why we sort my *label* is because that's the only thing presented
         // to users' eyes. What the default sort is or what the order by 'key' is not
@@ -309,10 +309,18 @@ class FilterObjectForm extends React.PureComponent {
     // This is a simple object for counting how many settings have been set per tab.
     const countSettings = this.getSettingsCounts();
 
-    const initialLocales = filterObject.get('locales', List()).toArray();
-    const initialCountries = filterObject.get('countries', List()).toArray();
-    const initialChannels = filterObject.get('channels', List()).toArray();
-    const initialVersions = filterObject.get('versions', List()).toArray();
+    const initialLocales = filterObject
+      .get('locales', List())
+      .reduce((reduction, value) => [...reduction, value], []);
+    const initialCountries = filterObject
+      .get('countries', List())
+      .reduce((reduction, value) => [...reduction, value], []);
+    const initialChannels = filterObject
+      .get('channels', List())
+      .reduce((reduction, value) => [...reduction, value], []);
+    const initialVersions = filterObject
+      .get('versions', List())
+      .reduce((reduction, value) => [...reduction, value], []);
     const initialSampling = filterObject.get('_sampling', Map()).toJS();
 
     const tabLabels = {

--- a/src/workflows/recipes/components/RecipeDetails.js
+++ b/src/workflows/recipes/components/RecipeDetails.js
@@ -59,7 +59,7 @@ export default class RecipeDetails extends React.PureComponent {
                   actionName={actionName}
                 />,
               ])
-              .toArray()}
+              .reduce((reduction, value) => [...reduction, value], [])}
           </dl>
         </Card>
       </div>


### PR DESCRIPTION
Fixes #981. 

`.toArray` was changed in a recent version of Immutable. It used to discard the keys and return a flattened array of values. This call to `.reduce` recreates the previous implementation of `.toArray`.

r?