### PR TITLE
Add experimenter_slug to recipe details and form

### DIFF
--- a/src/workflows/recipes/components/RecipeDetails.js
+++ b/src/workflows/recipes/components/RecipeDetails.js
@@ -27,6 +27,9 @@ export default class RecipeDetails extends React.PureComponent {
             <dt>Name</dt>
             <ArgumentsValue name="name" value={revision.get('name')} />
 
+            <dt>Experimenter Slug</dt>
+            <ArgumentsValue name="experimenter_slug" value={revision.get('experimenter_slug')} />
+
             {filterObject && filterObject.size ? <dt>Filters</dt> : null}
             {filterObject && filterObject.size ? (
               <ArgumentsValue name="filter_object" value={revision.get('filter_object')} />

--- a/src/workflows/recipes/components/RecipeForm.js
+++ b/src/workflows/recipes/components/RecipeForm.js
@@ -55,6 +55,10 @@ export function cleanRecipeData(data) {
     throw new Error('Have you have at least one filter object or a filter expression.');
   }
 
+  if (data.experimenter_slug === '') {
+    data.experimenter_slug = null;
+  }
+
   // Make sure the action ID is an integer
   try {
     data.action_id = parseInt(data.action_id, 10);
@@ -197,6 +201,14 @@ class RecipeForm extends React.PureComponent {
             </FormItem>
           </Col>
         </Row>
+        <FormItem
+          name="experimenter_slug"
+          label="Experimenter Slug"
+          rules={[{ required: false }]}
+          initialValue={revision.get('experimenter_slug')}
+        >
+          <Input disabled={isLoading} />
+        </FormItem>
         {this.renderCommentField()}
         <FilterObjectForm
           form={this.props.form}


### PR DESCRIPTION
Fixes #808.

At present, Normandy server does not accept either empty strings or nulls for this field. Since the model already has `null=True`, I went with that approach, explicitly converting empty strings to nulls. I have opened https://github.com/mozilla/normandy/pull/2010 to support this on the server side.