### PR TITLE
Don't require reviews to merge with bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,7 +5,6 @@ status = [
   "ci/circleci: lint",
 ]
 block_labels = ["bors-dont-merge"]
-required_approvals = 1
 delete_merged_branches = true
 # Avoid including verbose details in commit messages
 cut_body_after = "\n---\n"


### PR DESCRIPTION
We decided this doesn't gain us much, and just gets in the way. We've removed this requirement from all the other product-delivery repos as well.