### PR TITLE
Add a widget for multi-pref-experiment branches

### DIFF
--- a/src/tests/workflows/recipes/components/RecipeDetails.test.js
+++ b/src/tests/workflows/recipes/components/RecipeDetails.test.js
@@ -62,7 +62,9 @@ describe('<ArgumentsValue>', () => {
       { slug: 'one', value: 1, ratio: 1 },
       { slug: 'two', value: 2, ratio: 3 },
     ]);
-    const wrapper = shallow(<ArgumentsValue actionName="preference-experiment" name="branches" value={value} />);
+    const wrapper = shallow(
+      <ArgumentsValue actionName="preference-experiment" name="branches" value={value} />,
+    );
     const children = wrapper.find('.value').children();
     expect(children.length).toBe(1);
     expect(children.type()).toBe('table');

--- a/src/tests/workflows/recipes/components/RecipeDetails.test.js
+++ b/src/tests/workflows/recipes/components/RecipeDetails.test.js
@@ -62,7 +62,7 @@ describe('<ArgumentsValue>', () => {
       { slug: 'one', value: 1, ratio: 1 },
       { slug: 'two', value: 2, ratio: 3 },
     ]);
-    const wrapper = shallow(<ArgumentsValue name="branches" value={value} />);
+    const wrapper = shallow(<ArgumentsValue actionName="preference-experiment" name="branches" value={value} />);
     const children = wrapper.find('.value').children();
     expect(children.length).toBe(1);
     expect(children.type()).toBe('table');


### PR DESCRIPTION
It's not the best UI, but it fits in the space and all the data is
available, which is more than can be said for the previous version.
Without this change there is simply no way to see the preference
changing or the value it is changing to.

## Before

![image](https://user-images.githubusercontent.com/305049/68439850-fdded380-017d-11ea-9e42-23c496bed730.png)

## After

![image](https://user-images.githubusercontent.com/305049/68439858-0505e180-017e-11ea-9e3a-55cc131d877a.png)


Fixes #1078