### PR TITLE
Add UI for editing multi-preference-experiment recipes

### DIFF
--- a/src/less/pages/recipe-form.less
+++ b/src/less/pages/recipe-form.less
@@ -64,6 +64,22 @@
     }
   }
 
+  .multi-pref-fields {
+    border-bottom: 1px solid @border-color-base;
+    margin-bottom: @form-item-margin-bottom;
+    padding-bottom: @form-item-margin-bottom;
+
+    &:last-of-type {
+      border-bottom: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .ant-form-item-label {
+      font-weight: bold;
+    }
+  }
+
   // Force form fields in the branch listing to be displayed inline.
   .ant-form-inline();
 }

--- a/src/less/pages/recipe-form.less
+++ b/src/less/pages/recipe-form.less
@@ -74,7 +74,7 @@
       margin-bottom: 0;
       padding-bottom: 0;
       
-     .ant-form-item-label {
+    .ant-form-item-label {
       font-weight: bold;
     }
   }

--- a/src/less/pages/recipe-form.less
+++ b/src/less/pages/recipe-form.less
@@ -73,17 +73,17 @@
       border-bottom: none;
       margin-bottom: 0;
       padding-bottom: 0;
-      
+    }
+
     .ant-form-item-label {
       font-weight: bold;
     }
   }
-  
+
   .branch-extension-fields {
     .ant-form-item,
     .ant-form-item > .ant-form-item-control-wrapper {
       display: block;
-
     }
 
     .ant-form-item-label {

--- a/src/workflows/recipes/components/MultiPreferenceExperimentBranchFields.js
+++ b/src/workflows/recipes/components/MultiPreferenceExperimentBranchFields.js
@@ -1,0 +1,260 @@
+import { Button, Input, InputNumber, Select } from 'antd';
+import autobind from 'autobind-decorator';
+import { List, Map } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import FormItem from 'console/components/forms/FormItem';
+import BooleanPreferenceField from 'console/workflows/recipes/components/BooleanPreferenceField';
+import IntegerPreferenceField from 'console/workflows/recipes/components/IntegerPreferenceField';
+import PreferenceBranchSelect from 'console/workflows/recipes/components/PreferenceBranchSelect';
+import StringPreferenceField from 'console/workflows/recipes/components/StringPreferenceField';
+import { connectFormProps } from 'console/utils/forms';
+
+@connectFormProps
+@autobind
+class MultiPreferenceExperimentBranchFields extends React.PureComponent {
+  static propTypes = {
+    branch: PropTypes.instanceOf(Map).isRequired,
+    disabled: PropTypes.bool,
+    fieldName: PropTypes.string.isRequired,
+    form: PropTypes.object.isRequired,
+    index: PropTypes.number.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onClickDelete: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    disabled: false,
+  };
+
+  handleClickDelete() {
+    const { index, onClickDelete } = this.props;
+    onClickDelete(index);
+  }
+
+  // Bind the name parameter to individual functions to avoid re-renders due
+  // to prop comparison and anonymous functions.
+  handleChangeSlug(event) {
+    this.handleChange('slug', event);
+  }
+
+  handleChangeRatio(event) {
+    this.handleChange('ratio', event);
+  }
+
+  handleChangePreferences(event) {
+    this.handleChange('preferences', event);
+  }
+
+  handleChange(name, event) {
+    const { branch, index, onChange } = this.props;
+
+    // InputNumber passes the value as the parameter, but Input and
+    // Radio pass it via event.target.value.
+    let value = event;
+    if (event && event.target) {
+      value = event.target.value;
+    }
+
+    onChange(index, branch.set(name, value));
+  }
+
+  render() {
+    const { branch, disabled, fieldName } = this.props;
+    return (
+      <React.Fragment>
+        <div className="branch-fields">
+          <FormItem label="Branch Name" name={`${fieldName}.slug`} connectToForm={false}>
+            <Input
+              disabled={disabled}
+              value={branch.get('slug', '')}
+              onChange={this.handleChangeSlug}
+              id="pef-branch-name"
+            />
+          </FormItem>
+          <FormItem label="Ratio" name={`${fieldName}.ratio`} connectToForm={false}>
+            <InputNumber
+              disabled={disabled}
+              value={branch.get('ratio', '')}
+              onChange={this.handleChangeRatio}
+            />
+          </FormItem>
+          <Button
+            className="delete-btn"
+            disabled={disabled}
+            type="danger"
+            icon="close"
+            onClick={this.handleClickDelete}
+          >
+            Delete Branch
+          </Button>
+        </div>
+        <BranchPreferences
+          disabled={disabled}
+          preferences={branch.get('preferences')}
+          onChange={this.handleChangePreferences}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+@autobind
+class BranchPreferences extends React.PureComponent {
+  handleChange(prefName, pref, oldPrefName) {
+    const { onChange, preferences } = this.props;
+    let updated = preferences.set(prefName, pref);
+    if ((oldPrefName || oldPrefName === '') && oldPrefName !== prefName) {
+      updated = updated.delete(oldPrefName);
+    }
+    onChange(updated);
+  }
+
+  handleClickAdd() {
+    this.handleChange(
+      '',
+      new Map({
+        preferenceValue: '',
+        preferenceType: 'string',
+        preferenceBranchType: 'default',
+      }),
+    );
+  }
+
+  deletePreference(prefName) {
+    const { onChange, preferences } = this.props;
+    onChange(preferences.delete(prefName));
+  }
+
+  render() {
+    const { disabled, preferences } = this.props;
+    return (
+      <div className="branch-prefs">
+        <strong>Branch Preferences</strong>
+        <ul>
+          {List(preferences).map(([prefName, pref], index) => (
+            <PreferenceFields
+              key={index}
+              disabled={disabled}
+              prefName={prefName}
+              pref={pref}
+              onChange={this.handleChange}
+              deletePreference={this.deletePreference}
+            />
+          ))}
+        </ul>
+        <Button
+          disabled={disabled || preferences.keySeq().includes('')}
+          type="default"
+          icon="plus"
+          onClick={this.handleClickAdd}
+        >
+          Add Preference
+        </Button>
+      </div>
+    );
+  }
+}
+
+@autobind
+class PreferenceFields extends React.PureComponent {
+  static VALUE_FIELDS = {
+    string: StringPreferenceField,
+    integer: IntegerPreferenceField,
+    boolean: BooleanPreferenceField,
+  };
+
+  handleChangePrefName(event) {
+    const { onChange, pref, prefName } = this.props;
+    onChange(event.target.value, pref, prefName);
+  }
+
+  handleChangePrefBranchType(value) {
+    const { onChange, pref, prefName } = this.props;
+    onChange(prefName, pref.set('preferenceBranchType', value));
+  }
+
+  handleChangePrefType(value) {
+    const { onChange, pref, prefName } = this.props;
+    onChange(prefName, pref.set('preferenceType', value));
+  }
+
+  handleChangePrefValue(event) {
+    const { onChange, pref, prefName } = this.props;
+
+    // InputNumber passes the value as the parameter, but Input and
+    // Radio pass it via event.target.value.
+    let value = event;
+    if (event && event.target) {
+      value = event.target.value;
+    }
+
+    onChange(prefName, pref.set('preferenceValue', value));
+  }
+
+  handleClickDelete() {
+    const { deletePreference, prefName } = this.props;
+    deletePreference(prefName);
+  }
+
+  render() {
+    const { disabled, prefName, pref } = this.props;
+    const ValueField = PreferenceFields.VALUE_FIELDS[pref.get('preferenceType')];
+
+    return (
+      <li className="multi-pref-fields">
+        <div>
+          <FormItem label="Preference Name" name={`preferenceName`} connectToForm={false}>
+            <Input disabled={disabled} value={prefName} onChange={this.handleChangePrefName} />
+          </FormItem>
+
+          <FormItem
+            label="Preference Branch Type"
+            name="preferenceBranchType"
+            connectToForm={false}
+          >
+            <PreferenceBranchSelect
+              disabled={disabled}
+              value={pref.get('preferenceBranchType')}
+              onChange={this.handleChangePrefBranchType}
+            />
+          </FormItem>
+
+          <Button
+            className="delete-btn"
+            disabled={disabled}
+            type="danger"
+            icon="close"
+            onClick={this.handleClickDelete}
+          >
+            Delete Preference
+          </Button>
+        </div>
+        <div>
+          <FormItem label="Preference Type" name="preferenceType" connectToForm={false}>
+            <Select
+              value={pref.get('preferenceType')}
+              disabled={disabled}
+              onChange={this.handleChangePrefType}
+            >
+              <Select.Option value="boolean">Boolean</Select.Option>
+              <Select.Option value="integer">Integer</Select.Option>
+              <Select.Option value="string">String</Select.Option>
+            </Select>
+          </FormItem>
+
+          <FormItem label="Preference Value" name="preferenceValue" connectToForm={false}>
+            <ValueField
+              disabled={disabled}
+              value={pref.get('preferenceValue')}
+              onChange={this.handleChangePrefValue}
+            />
+          </FormItem>
+        </div>
+      </li>
+    );
+  }
+}
+
+export default MultiPreferenceExperimentBranchFields;

--- a/src/workflows/recipes/components/MultiPreferenceExperimentBranches.js
+++ b/src/workflows/recipes/components/MultiPreferenceExperimentBranches.js
@@ -1,0 +1,86 @@
+import { Button } from 'antd';
+import autobind from 'autobind-decorator';
+import { List, Map } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import MultiPreferenceExperimentBranchFields from 'console/workflows/recipes/components/MultiPreferenceExperimentBranchFields';
+import { connectFormProps } from 'console/utils/forms';
+
+/**
+ * List of individual branches in the experiment.
+ *
+ * rc-form's implementation of nested data is buggy[1].  It only reliably
+ * supports one level of nesting, but branches end up having deeply-nested
+ * fields like arguments.branches[1].slug. As a workaround, ExperimentBranches
+ * acts as an input for a single value, and manages the nesting internally,
+ * sending it back to rc-form via the onChange prop.
+ *
+ * [1] https://github.com/ant-design/ant-design/issues/4711
+ */
+@connectFormProps
+@autobind
+class MultiPreferenceExperimentBranches extends React.PureComponent {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    onChange: PropTypes.func.isRequired,
+    branches: PropTypes.instanceOf(List).isRequired,
+  };
+
+  static defaultProps = {
+    disabled: false,
+  };
+
+  handleClickDelete(index) {
+    const { branches, onChange } = this.props;
+    onChange(branches.delete(index));
+  }
+
+  handleClickAdd() {
+    const { branches, onChange } = this.props;
+    const branch = new Map({
+      slug: '',
+      preferences: new Map(),
+      ratio: 1,
+    });
+    onChange(branches.push(branch));
+  }
+
+  handleChangeBranch(index, branch) {
+    const { branches, onChange } = this.props;
+    onChange(branches.set(index, branch));
+  }
+
+  render() {
+    const { branches, disabled } = this.props;
+    return (
+      <div>
+        <ul className="branch-list">
+          {branches.map((branch, index) => (
+            <li key={index} className="branch">
+              <MultiPreferenceExperimentBranchFields
+                disabled={disabled}
+                branch={branch}
+                fieldName={`arguments.branches[${index}]`}
+                index={index}
+                onChange={this.handleChangeBranch}
+                onClickDelete={this.handleClickDelete}
+              />
+            </li>
+          ))}
+        </ul>
+        <Button
+          disabled={disabled}
+          type="default"
+          icon="plus"
+          onClick={this.handleClickAdd}
+          id="add-branch"
+        >
+          Add Branch
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default MultiPreferenceExperimentBranches;

--- a/src/workflows/recipes/components/MultiPreferenceExperimentFields.js
+++ b/src/workflows/recipes/components/MultiPreferenceExperimentFields.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-boolean-value */
-import { Row, Col, Alert, Input, Select } from 'antd';
+import { Row, Col, Input } from 'antd';
 import { List, Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,12 +7,11 @@ import React from 'react';
 import DocumentUrlInput from 'console/components/forms/DocumentUrlInput';
 import FormItem from 'console/components/forms/FormItem';
 import SwitchBox from 'console/components/forms/SwitchBox';
-import PreferenceExperimentBranches from 'console/workflows/recipes/components/PreferenceExperimentBranches';
-import PreferenceBranchSelect from 'console/workflows/recipes/components/PreferenceBranchSelect';
+import MultiPreferenceExperimentBranches from 'console/workflows/recipes/components/MultiPreferenceExperimentBranches';
 import { connectFormProps } from 'console/utils/forms';
 
 @connectFormProps
-class PreferenceExperimentFields extends React.Component {
+class MultiPreferenceExperimentFields extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool,
     form: PropTypes.object.isRequired,
@@ -31,7 +30,7 @@ class PreferenceExperimentFields extends React.Component {
 
     return (
       <Row>
-        <p className="action-info">Run a feature experiment activated by a preference.</p>
+        <p className="action-info">Run a feature experiment activated by multiple preference.</p>
         <Col sm={24} md={11}>
           <FormItem
             label="Experiment Name"
@@ -42,11 +41,11 @@ class PreferenceExperimentFields extends React.Component {
           </FormItem>
 
           <FormItem
-            label="Experiment Document URL"
-            name="arguments.experimentDocumentUrl"
-            initialValue={recipeArguments.get('experimentDocumentUrl', '')}
+            label="User Facing Name"
+            name="arguments.userFacingName"
+            initialValue={recipeArguments.get('userFacingName', '')}
           >
-            <DocumentUrlInput disabled={disabled} />
+            <Input disabled={disabled} />
           </FormItem>
 
           <FormItem
@@ -64,54 +63,20 @@ class PreferenceExperimentFields extends React.Component {
 
         <Col sm={24} md={{ span: 12, offset: 1 }}>
           <FormItem
-            label="Preference Name"
-            name="arguments.preferenceName"
-            initialValue={recipeArguments.get('preferenceName', '')}
-            trimWhitespace
+            label="Experiment Document URL"
+            name="arguments.experimentDocumentUrl"
+            initialValue={recipeArguments.get('experimentDocumentUrl', '')}
+          >
+            <DocumentUrlInput disabled={disabled} />
+          </FormItem>
+
+          <FormItem
+            label="User Facing Description"
+            name="arguments.userFacingDescription"
+            initialValue={recipeArguments.get('userFacingDescription', '')}
           >
             <Input disabled={disabled} />
           </FormItem>
-
-          <Col sm={24}>
-            <Col xs={24} sm={11}>
-              <FormItem
-                label="Preference Type"
-                name="arguments.preferenceType"
-                initialValue={recipeArguments.get('preferenceType', 'boolean')}
-              >
-                <Select disabled={disabled}>
-                  <Select.Option value="boolean">Boolean</Select.Option>
-                  <Select.Option value="integer">Integer</Select.Option>
-                  <Select.Option value="string">String</Select.Option>
-                </Select>
-              </FormItem>
-            </Col>
-            <Col xs={24} sm={{ span: 12, offset: 1 }}>
-              <FormItem
-                label="Preference Branch Type"
-                name="arguments.preferenceBranchType"
-                initialValue={recipeArguments.get('preferenceBranchType', 'default')}
-              >
-                <PreferenceBranchSelect disabled={disabled} />
-              </FormItem>
-            </Col>
-            {isUserBranchSelected && (
-              <Col xs={24}>
-                <Alert
-                  message="User Preference Branch"
-                  description={
-                    <span>
-                      Setting user preferences instead of default ones is not recommended.
-                      <br />
-                      Do not choose this unless you know what you are doing.
-                    </span>
-                  }
-                  type="warning"
-                  showIcon
-                />
-              </Col>
-            )}
-          </Col>
         </Col>
 
         <Col
@@ -140,7 +105,7 @@ class PreferenceExperimentFields extends React.Component {
             initialValue={recipeArguments.get('branches', new List())}
             config={{ valuePropName: 'branches' }}
           >
-            <PreferenceExperimentBranches disabled={disabled} />
+            <MultiPreferenceExperimentBranches disabled={disabled} />
           </FormItem>
         </Col>
       </Row>
@@ -148,4 +113,4 @@ class PreferenceExperimentFields extends React.Component {
   }
 }
 
-export default PreferenceExperimentFields;
+export default MultiPreferenceExperimentFields;

--- a/src/workflows/recipes/components/PreferenceExperimentBranchFields.js
+++ b/src/workflows/recipes/components/PreferenceExperimentBranchFields.js
@@ -12,7 +12,7 @@ import { connectFormProps } from 'console/utils/forms';
 
 @connectFormProps
 @autobind
-class ExperimentBranchFields extends React.PureComponent {
+class PreferenceExperimentBranchFields extends React.PureComponent {
   static propTypes = {
     branch: PropTypes.instanceOf(Map).isRequired,
     disabled: PropTypes.bool,
@@ -68,7 +68,7 @@ class ExperimentBranchFields extends React.PureComponent {
   render() {
     const { branch, disabled, fieldName, form } = this.props;
     const preferenceType = form.getFieldValue('arguments.preferenceType');
-    const ValueField = ExperimentBranchFields.VALUE_FIELDS[preferenceType];
+    const ValueField = PreferenceExperimentBranchFields.VALUE_FIELDS[preferenceType];
     return (
       <div className="branch-fields">
         <FormItem label="Branch Name" name={`${fieldName}.slug`} connectToForm={false}>
@@ -107,4 +107,4 @@ class ExperimentBranchFields extends React.PureComponent {
   }
 }
 
-export default ExperimentBranchFields;
+export default PreferenceExperimentBranchFields;

--- a/src/workflows/recipes/components/PreferenceExperimentBranches.js
+++ b/src/workflows/recipes/components/PreferenceExperimentBranches.js
@@ -4,7 +4,7 @@ import { List, Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ExperimentBranchFields from 'console/workflows/recipes/components/ExperimentBranchFields';
+import PreferenceExperimentBranchFields from 'console/workflows/recipes/components/PreferenceExperimentBranchFields';
 import { connectFormProps } from 'console/utils/forms';
 
 /**
@@ -20,7 +20,7 @@ import { connectFormProps } from 'console/utils/forms';
  */
 @connectFormProps
 @autobind
-class ExperimentBranches extends React.PureComponent {
+class PreferenceExperimentBranches extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -58,7 +58,7 @@ class ExperimentBranches extends React.PureComponent {
         <ul className="branch-list">
           {branches.map((branch, index) => (
             <li key={index} className="branch">
-              <ExperimentBranchFields
+              <PreferenceExperimentBranchFields
                 disabled={disabled}
                 branch={branch}
                 fieldName={`arguments.branches[${index}]`}
@@ -83,4 +83,4 @@ class ExperimentBranches extends React.PureComponent {
   }
 }
 
-export default ExperimentBranches;
+export default PreferenceExperimentBranches;

--- a/src/workflows/recipes/components/RecipeDetails.js
+++ b/src/workflows/recipes/components/RecipeDetails.js
@@ -154,12 +154,12 @@ export class ArgumentsValue extends React.PureComponent {
             .map(([preferenceName, spec]) => spec.set('preferenceName', preferenceName))
             .toJS();
           return (
-            <div data-table-data={JSON.stringify(data)}>
-              <h2>
+            <React.Fragment key={branch.get('slug')}>
+              <h3 style={{ marginBottom: 0, fontWeight: 'bold' }}>
                 {branch.get('slug')} - {Math.round((branch.get('ratio') / sumRatios) * 100)}%
-              </h2>
+              </h3>
               <Table columns={columns} dataSource={data} pagination={false} size="small" />
-            </div>
+            </React.Fragment>
           );
         })}
       </ul>

--- a/src/workflows/recipes/components/RecipeForm.js
+++ b/src/workflows/recipes/components/RecipeForm.js
@@ -14,6 +14,7 @@ import FilterObjectForm, {
   deserializeFilterObjectToList,
 } from 'console/workflows/recipes/components/FilterObjectForm';
 import JSONArgumentsField from 'console/workflows/recipes/components/JSONArgumentsField';
+import MultiPreferenceExperimentFields from 'console/workflows/recipes/components/MultiPreferenceExperimentFields';
 import PreferenceExperimentFields from 'console/workflows/recipes/components/PreferenceExperimentFields';
 import PreferenceRolloutFields, {
   deserializePreferenceRows,
@@ -109,6 +110,7 @@ class RecipeForm extends React.PureComponent {
     'preference-rollout': PreferenceRolloutFields,
     'preference-rollback': PreferenceRollbackFields,
     'opt-out-study': AddonStudyFields,
+    'multi-preference-experiment': MultiPreferenceExperimentFields,
   };
 
   constructor(props) {


### PR DESCRIPTION
Not the prettiest thing in the world but it gets the job done. 

![image](https://user-images.githubusercontent.com/987136/69329689-8f1e7180-0c77-11ea-9c7a-6f07807ef47e.png)

There's a little bit of a gotcha that I couldn't solve without a massive overhaul of the forms (which didn't seem worth it) --- if you are typing a preference name and it happens to match an existing preference name, the existing pref will get overwritten with the one you are currently editing. In most cases I'm assuming users will be copying and pasting these pref names in so this should not be a problem. 